### PR TITLE
Clip onClick ripples to card shapes

### DIFF
--- a/app/src/main/java/com/shub39/grit/ui/component/HabitAnalyticsCard.kt
+++ b/app/src/main/java/com/shub39/grit/ui/component/HabitAnalyticsCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -24,9 +26,11 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.shub39.grit.R
 import com.shub39.grit.database.habit.Habit
@@ -56,7 +60,12 @@ fun HabitAnalyticsCard(
         modifier = Modifier
             .fillMaxWidth()
             .padding(top = 4.dp, bottom = 4.dp)
-            .clickable { onItemClick() },
+            .clip(MaterialTheme.shapes.extraLarge)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(true, radius = Dp.Infinity),
+                onClick = { onItemClick() }
+            ),
         shape = MaterialTheme.shapes.extraLarge
     ) {
         Column(

--- a/app/src/main/java/com/shub39/grit/ui/component/TaskCard.kt
+++ b/app/src/main/java/com/shub39/grit/ui/component/TaskCard.kt
@@ -1,10 +1,8 @@
 package com.shub39.grit.ui.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardColors
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,7 +11,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -39,14 +36,11 @@ fun TaskCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
-            .clickable {
-                taskStatus = !taskStatus
-                task.status = !task.status
-                onStatusChange(task)
-            },
-        colors = getCardColors(task.priority),
-        shape = MaterialTheme.shapes.extraLarge
+            .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp), onClick = {
+            taskStatus = !taskStatus
+            task.status = !task.status
+            onStatusChange(task)
+        }, colors = getCardColors(task.priority), shape = MaterialTheme.shapes.extraLarge
     ) {
         Text(
             text = task.title,

--- a/app/src/main/java/com/shub39/grit/ui/page/SettingsPage.kt
+++ b/app/src/main/java/com/shub39/grit/ui/page/SettingsPage.kt
@@ -1,8 +1,6 @@
 package com.shub39.grit.ui.page
 
 import android.os.Build
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
@@ -158,30 +158,27 @@ fun SettingsPage(
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.github_mark),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(32.dp)
-                            .clickable {
-                                openLinkInBrowser(context, "https://github.com/shub39/Grit")
-                            }
-                    )
+                    IconButton(modifier = Modifier.size(32.dp), onClick = {
+                        openLinkInBrowser(context, "https://github.com/shub39/Grit")
+                    }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.github_mark),
+                            contentDescription = null,
+                        )
+                    }
 
                     Spacer(modifier = Modifier.padding(8.dp))
 
-                    Image(
-                        painter = painterResource(id = R.drawable.discord_svgrepo_com),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(32.dp)
-                            .clickable {
-                                openLinkInBrowser(
-                                    context,
-                                    "https://discord.gg/https://discord.gg/nxA2hgtEKf"
-                                )
-                            }
-                    )
+                    IconButton(modifier = Modifier.size(32.dp), onClick = {
+                        openLinkInBrowser(
+                            context, "https://discord.gg/https://discord.gg/nxA2hgtEKf"
+                        )
+                    }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.discord_svgrepo_com),
+                            contentDescription = null,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a purely aesthetic change for
- TaskCard
- HabitAnalyticsCard
- Github & Discord images

when clicked on them. The ripple effect should no longer be square and instead neatly clip.