### PR TITLE
Allow habit overview widget to have 2x1 minimum size

### DIFF
--- a/app/src/main/res/xml-v31/overview_widget.xml
+++ b/app/src/main/res/xml-v31/overview_widget.xml
@@ -1,9 +1,9 @@
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:targetCellWidth="2"
+    android:targetCellWidth="4"
     android:description="@string/habit_overview_widget"
-    android:targetCellHeight="1"
+    android:targetCellHeight="2"
     android:minWidth="120dp"
     android:minHeight="60dp"
     android:updatePeriodMillis="3600000"

--- a/app/src/main/res/xml-v31/overview_widget.xml
+++ b/app/src/main/res/xml-v31/overview_widget.xml
@@ -1,12 +1,12 @@
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/glance_default_loading_layout"
-    android:targetCellWidth="4"
+    android:targetCellWidth="2"
     android:description="@string/habit_overview_widget"
-    android:targetCellHeight="2"
+    android:targetCellHeight="1"
     android:minWidth="120dp"
-    android:minHeight="100dp"
+    android:minHeight="60dp"
     android:updatePeriodMillis="3600000"
     android:widgetCategory="home_screen"
     android:previewImage="@drawable/habit_overview_widget"
-    android:resizeMode="vertical" />
+    android:resizeMode="horizontal|vertical" />

--- a/app/src/main/res/xml/overview_widget.xml
+++ b/app/src/main/res/xml/overview_widget.xml
@@ -2,6 +2,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/glance_default_loading_layout"
     android:minWidth="100dp"
-    android:minHeight="120dp"
+    android:minHeight="30dp"
     android:updatePeriodMillis="3600000"
-    android:resizeMode="vertical" />
+    android:resizeMode="horizontal|vertical" />


### PR DESCRIPTION
Have been using Grit recently (very nice btw) and this was one bugbear I had. I noticed your roadmap had a similar task in it so here it is in some form...

v31+ defaults to the original size (4x2) but can shrink down to 2x1
pre-v31 defaults to 2x1 due to how the widgetprovider seems to work there

tested both cases in emulators

feel free to reject in case you're planning on doing this differently