### PR TITLE
fix: add ui for habit edit/delete

### DIFF
--- a/app/src/main/java/com/shub39/grit/habits/presentation/ui/component/HabitCard.kt
+++ b/app/src/main/java/com/shub39/grit/habits/presentation/ui/component/HabitCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -55,6 +56,7 @@ fun HabitCard(
     completed: Boolean,
     action: (HabitsPageAction) -> Unit,
     onNavigateToAnalytics: () -> Unit,
+    onEditHabit: (Habit) -> Unit,
     editState: Boolean,
     compactView: Boolean,
     startingDay: DayOfWeek,
@@ -98,13 +100,21 @@ fun HabitCard(
             containerColor = cardBackground,
             contentColor = cardContent
         ),
-        onClick = {
-            if (canCompleteToday) {
-                action(HabitsPageAction.InsertStatus(habit))
-            }
-        },
         shape = shape,
-        modifier = modifier.animateContentSize()
+        modifier = modifier
+            .animateContentSize()
+            .combinedClickable(
+                onClick = {
+                    if (canCompleteToday) {
+                        action(HabitsPageAction.InsertStatus(habit))
+                    }
+                },
+                onLongClick = {
+                    if (!editState) {
+                        onEditHabit(habit)
+                    }
+                }
+            )
     ) {
         ListItem(
             modifier = Modifier

--- a/app/src/main/java/com/shub39/grit/habits/presentation/ui/component/HabitUpsertSheet.kt
+++ b/app/src/main/java/com/shub39/grit/habits/presentation/ui/component/HabitUpsertSheet.kt
@@ -16,12 +16,16 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Alarm
 import androidx.compose.material.icons.rounded.Create
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonShapes
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -40,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
@@ -63,13 +68,15 @@ fun HabitUpsertSheet(
     onUpsertHabit: (Habit) -> Unit,
     is24Hr: Boolean,
     modifier: Modifier = Modifier,
-    edit: Boolean = false
+    edit: Boolean = false,
+    onDelete: ((Habit) -> Unit)? = null
 ) {
     val context = LocalContext.current
 
     var newHabit by remember { mutableStateOf(habit) }
 
     var timePickerDialog by remember { mutableStateOf(false) }
+    var deleteDialog by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
@@ -241,6 +248,23 @@ fun HabitUpsertSheet(
             Text(text = stringResource(id = if (edit) R.string.update else R.string.add_habit))
         }
 
+        if (edit && onDelete != null) {
+            OutlinedButton(
+                onClick = { deleteDialog = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Delete,
+                    contentDescription = "Delete Habit"
+                )
+                Spacer(modifier = Modifier.padding(4.dp))
+                Text(text = stringResource(R.string.delete))
+            }
+        }
+
         if (timePickerDialog) {
             val timePickerState = rememberTimePickerState(
                 initialHour = newHabit.time.hour,
@@ -284,6 +308,43 @@ fun HabitUpsertSheet(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(text = stringResource(R.string.done))
+                }
+            }
+        }
+
+        if (deleteDialog) {
+            GritDialog(
+                onDismissRequest = { deleteDialog = false }
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Warning,
+                    contentDescription = "Warning"
+                )
+
+                Text(
+                    text = stringResource(R.string.delete),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Text(
+                    text = stringResource(id = R.string.delete_warning),
+                    textAlign = TextAlign.Center
+                )
+
+                Button(
+                    onClick = {
+                        deleteDialog = false
+                        onDismissRequest()
+                        onDelete?.invoke(habit)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text(text = stringResource(id = R.string.delete))
                 }
             }
         }

--- a/app/src/main/java/com/shub39/grit/habits/presentation/ui/section/HabitsList.kt
+++ b/app/src/main/java/com/shub39/grit/habits/presentation/ui/section/HabitsList.kt
@@ -2,6 +2,7 @@ package com.shub39.grit.habits.presentation.ui.section
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -69,6 +70,7 @@ fun HabitsList(
     onNavigateToOverallAnalytics: () -> Unit
 ) = PageFill {
     var editState by remember { mutableStateOf(false) }
+    var editHabit: Habit? by remember { mutableStateOf(null) }
     val lazyListState = rememberLazyListState()
     val fabVisible by remember {
         derivedStateOf {
@@ -180,6 +182,7 @@ fun HabitsList(
                         startingDay = state.startingDay,
                         editState = editState,
                         onNavigateToAnalytics = onNavigateToAnalytics,
+                        onEditHabit = { habit -> editHabit = habit },
                         timeFormat = state.timeFormat,
                         reorderHandle = {
                             Icon(
@@ -276,6 +279,21 @@ fun HabitsList(
             timeFormat = state.timeFormat,
             onUpsertHabit = { onAction(HabitsPageAction.AddHabit(it)) },
             is24Hr = state.is24Hr,
+        )
+    }
+
+    // edit sheet
+    if (editHabit != null) {
+        HabitUpsertSheet(
+            habit = editHabit!!,
+            onDismissRequest = { editHabit = null },
+            timeFormat = state.timeFormat,
+            onUpsertHabit = { onAction(HabitsPageAction.UpdateHabit(it)) },
+            is24Hr = state.is24Hr,
+            edit = true,
+            onDelete = { habit ->
+                onAction(HabitsPageAction.DeleteHabit(habit))
+            }
         )
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/shub39/Grit/issues/165.

<img width="290" height="633" alt="image" src="https://github.com/user-attachments/assets/475eb687-17fe-43d2-b322-eeaf63c38c67" />

During my own tests I was not able to update / edit or delete a habit.

I added the same edit style akin to the tasks section. Because habits are not exactly like tasks I moved the delete action into the edit card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-press any habit card to enter edit mode and update habit details, settings, and configuration options
  * Delete habits with a protective confirmation dialog during editing to prevent accidental removal and unintended data loss
  * Enhanced habit management workflow with streamlined editing and removal capabilities fully integrated into the habits list interface for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->