### PR TITLE
feat(173): Edit previous habit days without having to open details menu.

### DIFF
--- a/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/HabitCard.kt
+++ b/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/HabitCard.kt
@@ -52,6 +52,7 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.todayIn
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun HabitCard(
@@ -206,12 +207,32 @@ fun HabitCard(
                         modifier = Modifier
                             .padding(2.dp)
                             .fillMaxWidth(1f)
+                            .clickable(
+                                role = Role.Button,
+                                enabled = validDay,
+                                onClick = {
+                                    action(
+                                        HabitsAction.InsertStatus(
+                                            habit = habitWithAnalytics.habit,
+                                            date = weekDay.date
+                                        )
+                                    )
+                                }
+                            )
                             .then(
                                 if (done) {
                                     val donePrevious =
-                                        habitWithAnalytics.statuses.any { it.date == weekDay.date.minusDays(1) }
+                                        habitWithAnalytics.statuses.any {
+                                            it.date == weekDay.date.minusDays(
+                                                1
+                                            )
+                                        }
                                     val doneAfter =
-                                        habitWithAnalytics.statuses.any { it.date == weekDay.date.plusDays(1) }
+                                        habitWithAnalytics.statuses.any {
+                                            it.date == weekDay.date.plusDays(
+                                                1
+                                            )
+                                        }
 
                                     Modifier.background(
                                         color = MaterialTheme.colorScheme.primary,
@@ -240,14 +261,7 @@ fun HabitCard(
                         contentAlignment = Alignment.Center
                     ) {
                         Column(
-                            modifier = Modifier
-                                .padding(6.dp)
-                                .clickable(role = Role.Button, onClick = {
-                                    action(HabitsAction.InsertStatus(
-                                        habit = habitWithAnalytics.habit,
-                                        date = weekDay.date
-                                    ))
-                                }),
+                            modifier = Modifier.padding(6.dp),
                             horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
                             Text(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Individual days in habit calendars are now clickable so you can record or toggle a habit status for any specific date directly from the calendar view.
  * Tapping the habit card itself still marks today's status as before, preserving the existing quick-complete behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->