### PR TITLE
Fix visual clipping across calendar and settings UI components.

### DIFF
--- a/app/src/main/java/com/shub39/grit/core/presentation/settings/ui/section/LookAndFeelPage.kt
+++ b/app/src/main/java/com/shub39/grit/core/presentation/settings/ui/section/LookAndFeelPage.kt
@@ -375,12 +375,12 @@ fun LookAndFeelPage(
                                 Box(
                                     modifier =
                                         Modifier.size(50.dp)
-                                            .background(
-                                                color = scheme.tertiary,
+                                            .clip(
                                                 shape =
                                                     if (selected) MaterialShapes.VerySunny.toShape()
-                                                    else CircleShape,
+                                                    else CircleShape
                                             )
+                                            .background(color = scheme.tertiary)
                                             .clickable {
                                                 onAction(SettingsAction.ChangePaletteStyle(style))
                                             },

--- a/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/CalendarMap.kt
+++ b/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/CalendarMap.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.kizitonwose.calendar.compose.CalendarState
@@ -145,6 +146,16 @@ fun CalendarMap(
                     val validDate =
                         day.date <= today && day.date.dayOfWeek in currentHabit.habit.days
 
+                    val donePrevious = day.date.minusDays(1) in doneDates
+                    val doneAfter = day.date.plusDays(1) in doneDates
+                    val streakPosition =
+                        when {
+                            donePrevious && doneAfter -> StreakPosition.MIDDLE
+                            donePrevious -> StreakPosition.END
+                            doneAfter -> StreakPosition.START
+                            else -> StreakPosition.ISOLATED
+                        }
+
                     Box(
                         modifier =
                             Modifier.padding(
@@ -156,6 +167,15 @@ fun CalendarMap(
                                 )
                                 .fillMaxWidth()
                                 .height(40.dp)
+                                .clip(
+                                    calendarMapStreakShape(
+                                        streakPosition = streakPosition,
+                                        isFirstDayOfWeek = day.date.dayOfWeek == edgeWeeks.first(),
+                                        isLastDayOfWeek = day.date.dayOfWeek == edgeWeeks.last(),
+                                        isFirstDayOfMonth = day.date.day == 1,
+                                        isLastDayOfMonth = day.date.plusDays(1).day == 1,
+                                    )
+                                )
                                 .clickable(enabled = validDate) {
                                     onAction(
                                         HabitsAction.InsertStatus(currentHabit.habit, day.date)
@@ -164,32 +184,10 @@ fun CalendarMap(
                         contentAlignment = Alignment.Center,
                     ) {
                         if (done) {
-                            val donePrevious = day.date.minusDays(1) in doneDates
-                            val doneAfter = day.date.plusDays(1) in doneDates
-                            val streakPosition =
-                                when {
-                                    donePrevious && doneAfter -> StreakPosition.MIDDLE
-                                    donePrevious -> StreakPosition.END
-                                    doneAfter -> StreakPosition.START
-                                    else -> StreakPosition.ISOLATED
-                                }
-
                             Box(
                                 modifier =
                                     Modifier.fillMaxSize()
-                                        .background(
-                                            color = MaterialTheme.colorScheme.primary,
-                                            shape =
-                                                calendarMapStreakShape(
-                                                    streakPosition = streakPosition,
-                                                    isFirstDayOfWeek =
-                                                        day.date.dayOfWeek == edgeWeeks.first(),
-                                                    isLastDayOfWeek =
-                                                        day.date.dayOfWeek == edgeWeeks.last(),
-                                                    isFirstDayOfMonth = day.date.day == 1,
-                                                    isLastDayOfMonth = day.date.plusDays(1).day == 1,
-                                                ),
-                                        ),
+                                        .background(color = MaterialTheme.colorScheme.primary),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 val isStreakEnd =

--- a/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/HabitCard.kt
+++ b/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/HabitCard.kt
@@ -252,18 +252,6 @@ fun HabitCard(
                     Box(
                         modifier =
                             Modifier.fillMaxWidth()
-                                .clickable(
-                                    role = Role.Button,
-                                    enabled = validDay,
-                                    onClick = {
-                                        action(
-                                            HabitsAction.InsertStatus(
-                                                habit = habitWithAnalytics.habit,
-                                                date = weekDay.date,
-                                            )
-                                        )
-                                    },
-                                )
                                 .then(
                                     if (done) {
                                         val donePrevious =
@@ -299,6 +287,19 @@ fun HabitCard(
                                             shape = shape,
                                         )
                                     } else Modifier
+                                )
+                                .clip(shape = RoundedCornerShape(20.dp))
+                                .clickable(
+                                    role = Role.Button,
+                                    enabled = validDay,
+                                    onClick = {
+                                        action(
+                                            HabitsAction.InsertStatus(
+                                                habit = habitWithAnalytics.habit,
+                                                date = weekDay.date,
+                                            )
+                                        )
+                                    },
                                 ),
                         contentAlignment = Alignment.Center,
                     ) {

--- a/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/WeeklyBooleanHeatMap.kt
+++ b/shared/core/src/commonMain/kotlin/com/shub39/grit/core/habits/presentation/ui/component/WeeklyBooleanHeatMap.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import com.kizitonwose.calendar.compose.HeatMapCalendar
 import com.kizitonwose.calendar.compose.heatmapcalendar.HeatMapCalendarState
@@ -170,40 +171,38 @@ fun WeeklyBooleanHeatMap(
                         val done = day.date in doneDates
                         val validDay = day.date.dayOfWeek in habit.days
 
+                        val donePrevious = day.date.minusDays(1) in doneDates
+                        val doneAfter = day.date.plusDays(1) in doneDates
+                        val streakPosition =
+                            when {
+                                donePrevious && doneAfter -> StreakPosition.MIDDLE
+                                donePrevious -> StreakPosition.END
+                                doneAfter -> StreakPosition.START
+                                else -> StreakPosition.ISOLATED
+                            }
+
+                        val shape =
+                            heatMapStreakShape(
+                                streakPosition = streakPosition,
+                                isFirstDayOfWeek = day.date.dayOfWeek == edgeWeeks.first(),
+                                isLastDayOfWeek = day.date.dayOfWeek == edgeWeeks.last(),
+                            )
+
                         Box(
                             modifier =
-                                Modifier.padding(horizontal = 1.dp).size(35.dp).clickable(
-                                    enabled = validDay
-                                ) {
-                                    onAction(HabitsAction.InsertStatus(habit, day.date))
-                                },
+                                Modifier.padding(horizontal = 1.dp)
+                                    .size(35.dp)
+                                    .clip(shape)
+                                    .clickable(enabled = validDay) {
+                                        onAction(HabitsAction.InsertStatus(habit, day.date))
+                                    },
                             contentAlignment = Alignment.Center,
                         ) {
                             if (done) {
-                                val donePrevious = day.date.minusDays(1) in doneDates
-                                val doneAfter = day.date.plusDays(1) in doneDates
-                                val streakPosition =
-                                    when {
-                                        donePrevious && doneAfter -> StreakPosition.MIDDLE
-                                        donePrevious -> StreakPosition.END
-                                        doneAfter -> StreakPosition.START
-                                        else -> StreakPosition.ISOLATED
-                                    }
-
                                 Box(
                                     modifier =
                                         Modifier.fillMaxSize()
-                                            .background(
-                                                color = MaterialTheme.colorScheme.primary,
-                                                shape =
-                                                    heatMapStreakShape(
-                                                        streakPosition = streakPosition,
-                                                        isFirstDayOfWeek =
-                                                            day.date.dayOfWeek == edgeWeeks.first(),
-                                                        isLastDayOfWeek =
-                                                            day.date.dayOfWeek == edgeWeeks.last(),
-                                                    ),
-                                            ),
+                                            .background(color = MaterialTheme.colorScheme.primary),
                                     contentAlignment = Alignment.Center,
                                 ) {
                                     val isStreakEnd =


### PR DESCRIPTION
In Compose, `background()` draws behind its modifier bounds and ignores the shape of a later `clip()`. The shape must be applied via `clip()` **before** `background()` so that both the background fill and the clickable ripple are correctly masked.

## Changes
- **CalendarMap**: apply `clip(calendarMapStreakShape(...))` on the outer Box; move `streakPosition` calculation outside the `if (done)` block so it's always available for shaping
- **HabitCard** (week calendar): add `clip(RoundedCornerShape(20.dp))` before `clickable` so ripples are clipped to the streak shape
- **WeeklyBooleanHeatMap**: same clip-before-background fix; compute `streakPosition` and `shape` unconditionally outside `if (done)`
- **LookAndFeelPage**: clip palette style Boxes to the VerySunny/Circle shape before applying background color

## Why
Without `clip()` before `background()`, the background bleeds outside the intended shape bounds, and the ripple on click ignores the shape entirely — visible as square corners on rounded/shaped elements.

### Before
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f61eb09e-08c0-4946-a21f-c3f0f75e6f03" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/3386496b-e1b3-44b0-b822-e650c04fabe1" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/ada2b8dd-e9e5-4c44-b346-bce673515535" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/9d451946-6f70-49a4-8e0b-52363658ee79" width="200"/></td>
  </tr>
  <tr>
    <td align="center">Habit Card</td>
    <td align="center">Look & Feel</td>
    <td align="center">Weekly Progress</td>
    <td align="center">Monthly Progress</td>
  </tr>
</table>

### After
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/915d70c1-04e8-4718-95bc-440aba0dffa0" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/dc0fa005-0f86-41ee-92d0-e2ab1574a808" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/03ed7dc2-36ab-4266-b304-e798ef600252" width="200"/></td>
    <td><img src="https://github.com/user-attachments/assets/bfbdcccf-9530-45c1-8094-480b16d626f4" width="200"/></td>
    
  </tr>
  <tr>
    <td align="center">Habit Card</td>
    <td align="center">Look & Feel</td>
    <td align="center">Weekly Progress</td>
    <td align="center">Monthly Progress</td>
  </tr>
</table>