### PR TITLE
Make FAB buttons in habit list disappear more quickly on scroll

### DIFF
--- a/shared/ui/src/commonMain/kotlin/com/shub39/grit/shared/ui/habit/ui/HabitsGraph.kt
+++ b/shared/ui/src/commonMain/kotlin/com/shub39/grit/shared/ui/habit/ui/HabitsGraph.kt
@@ -40,9 +40,11 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
@@ -129,8 +131,35 @@ fun HabitsGraph(
 
                             PageFill {
                                 val lazyListState = rememberLazyListState()
-                                val fabVisible by remember {
-                                    derivedStateOf { lazyListState.firstVisibleItemIndex == 0 }
+                                var fabVisible by remember { mutableStateOf(true) }
+                                var previousScrollOffset by remember { mutableStateOf(0) }
+
+                                LaunchedEffect(lazyListState) {
+                                    snapshotFlow {
+                                            lazyListState.firstVisibleItemIndex to
+                                                lazyListState.firstVisibleItemScrollOffset
+                                        }
+                                        .collect { (index, offset) ->
+                                            when {
+                                                index == 0 && offset == 0 -> {
+                                                    fabVisible = true
+                                                    previousScrollOffset = 0
+                                                }
+                                                index >= 1 -> {
+                                                    fabVisible = false
+                                                }
+                                                else -> {
+                                                    if (
+                                                        offset > previousScrollOffset && offset > 5
+                                                    ) {
+                                                        fabVisible = false
+                                                    } else if (offset < previousScrollOffset) {
+                                                        fabVisible = true
+                                                    }
+                                                    previousScrollOffset = offset
+                                                }
+                                            }
+                                        }
                                 }
 
                                 HabitsList(
@@ -243,8 +272,33 @@ private fun ExpandedScreen(
         Row(modifier = Modifier.weight(1f)) {
             Box {
                 val lazyListState = rememberLazyListState()
-                val fabVisible by remember {
-                    derivedStateOf { lazyListState.firstVisibleItemIndex == 0 }
+                var fabVisible by remember { mutableStateOf(true) }
+                var previousScrollOffset by remember { mutableStateOf(0) }
+
+                LaunchedEffect(lazyListState) {
+                    snapshotFlow {
+                            lazyListState.firstVisibleItemIndex to
+                                lazyListState.firstVisibleItemScrollOffset
+                        }
+                        .collect { (index, offset) ->
+                            when {
+                                index == 0 && offset == 0 -> {
+                                    fabVisible = true
+                                    previousScrollOffset = 0
+                                }
+                                index >= 1 -> {
+                                    fabVisible = false
+                                }
+                                else -> {
+                                    if (offset > previousScrollOffset && offset > 5) {
+                                        fabVisible = false
+                                    } else if (offset < previousScrollOffset) {
+                                        fabVisible = true
+                                    }
+                                    previousScrollOffset = offset
+                                }
+                            }
+                        }
                 }
 
                 HabitsList(

--- a/shared/ui/src/commonMain/kotlin/com/shub39/grit/shared/ui/habit/ui/HabitsGraph.kt
+++ b/shared/ui/src/commonMain/kotlin/com/shub39/grit/shared/ui/habit/ui/HabitsGraph.kt
@@ -40,11 +40,9 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
@@ -131,35 +129,11 @@ fun HabitsGraph(
 
                             PageFill {
                                 val lazyListState = rememberLazyListState()
-                                var fabVisible by remember { mutableStateOf(true) }
-                                var previousScrollOffset by remember { mutableStateOf(0) }
-
-                                LaunchedEffect(lazyListState) {
-                                    snapshotFlow {
-                                            lazyListState.firstVisibleItemIndex to
-                                                lazyListState.firstVisibleItemScrollOffset
-                                        }
-                                        .collect { (index, offset) ->
-                                            when {
-                                                index == 0 && offset == 0 -> {
-                                                    fabVisible = true
-                                                    previousScrollOffset = 0
-                                                }
-                                                index >= 1 -> {
-                                                    fabVisible = false
-                                                }
-                                                else -> {
-                                                    if (
-                                                        offset > previousScrollOffset && offset > 5
-                                                    ) {
-                                                        fabVisible = false
-                                                    } else if (offset < previousScrollOffset) {
-                                                        fabVisible = true
-                                                    }
-                                                    previousScrollOffset = offset
-                                                }
-                                            }
-                                        }
+                                val fabVisible by remember {
+                                    derivedStateOf {
+                                        lazyListState.firstVisibleItemIndex == 0 &&
+                                            lazyListState.firstVisibleItemScrollOffset == 0
+                                    }
                                 }
 
                                 HabitsList(
@@ -272,33 +246,11 @@ private fun ExpandedScreen(
         Row(modifier = Modifier.weight(1f)) {
             Box {
                 val lazyListState = rememberLazyListState()
-                var fabVisible by remember { mutableStateOf(true) }
-                var previousScrollOffset by remember { mutableStateOf(0) }
-
-                LaunchedEffect(lazyListState) {
-                    snapshotFlow {
-                            lazyListState.firstVisibleItemIndex to
-                                lazyListState.firstVisibleItemScrollOffset
-                        }
-                        .collect { (index, offset) ->
-                            when {
-                                index == 0 && offset == 0 -> {
-                                    fabVisible = true
-                                    previousScrollOffset = 0
-                                }
-                                index >= 1 -> {
-                                    fabVisible = false
-                                }
-                                else -> {
-                                    if (offset > previousScrollOffset && offset > 5) {
-                                        fabVisible = false
-                                    } else if (offset < previousScrollOffset) {
-                                        fabVisible = true
-                                    }
-                                    previousScrollOffset = offset
-                                }
-                            }
-                        }
+                val fabVisible by remember {
+                    derivedStateOf {
+                        lazyListState.firstVisibleItemIndex == 0 &&
+                            lazyListState.firstVisibleItemScrollOffset == 0
+                    }
                 }
 
                 HabitsList(


### PR DESCRIPTION
Currently, the FAB buttons in the habit list only hide when the first item of the list disappears completely from the screen. I noticed this was a problem when I added a new item recently and my list got to the exact size of my screen.
In this case, when scrolling down, the FAB buttons don't hide and overlays the buttons of the last habit. Here's what it looks like for me. 
<img width="1080" height="603" alt="Screenshot_20260620-112105" src="https://github.com/user-attachments/assets/b84a8cc6-3dda-41b5-9c3a-bb4a04c94fb3" />

I tried fixing this problem by making the FAB disappear whenever the first item in the list has been scrolled off from the top of the screen. Instead of hiding when the first item start being hidden by the header, it now hides instantly when the first item starts scrolling off.

I've tested this as best as I can and it seems to work like I intended !

As this is my first ever PR on an open source project, I hope I've done my best at explaining my issue and providing a fix, don't hesitate to ask me more questions if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating action button visibility behavior on the habits list to ensure it displays only when the list is scrolled to the very top.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->