### PR TITLE
Fixed dark mode navigation icons/buttons!

### DIFF
--- a/shared/ui/src/androidMain/kotlin/com/shub39/grit/shared/ui/theme/GritTheme.android.kt
+++ b/shared/ui/src/androidMain/kotlin/com/shub39/grit/shared/ui/theme/GritTheme.android.kt
@@ -16,6 +16,7 @@
  */
 package com.shub39.grit.shared.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialExpressiveTheme
@@ -23,8 +24,11 @@ import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import com.materialkolor.rememberDynamicColorScheme
 import com.shub39.grit.core.theme.Theme
 import com.shub39.grit.shared.ui.toFontRes
@@ -38,6 +42,16 @@ actual fun GritTheme(theme: Theme, content: @Composable (() -> Unit)) {
             LIGHT -> false
             DARK -> true
         }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            val insetsController = WindowCompat.getInsetsController(window, view)
+            insetsController.isAppearanceLightStatusBars = !isDark
+            insetsController.isAppearanceLightNavigationBars = !isDark
+        }
+    }
 
     val dynamicColorScheme =
         rememberDynamicColorScheme(


### PR DESCRIPTION
Previously, in dark mode the background for the Android navigation buttons at the bottom of the screen stayed white and the icons in the system tray at the top stayed black (making them almost invisible), this fixes that!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Android system bar icons to automatically match the app’s light or dark theme.
  * Improved readability and visual consistency for status and navigation bars across theme modes.
  * Prevented system bar configuration from affecting previews or design-time editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->